### PR TITLE
Fix docsify search plugin when cookies disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,32 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
     <link rel="stylesheet" href="css/terminusdb-docs.css">
     <link rel="icon" type="image/png" href="img/ico/terminusx-color.png">
+    <script>
+      // The docsify search plugin uses localStorage, which is not available on
+      // browsers when all cookies are strictly blocked, causing the page to
+      // not load on such browsers. To fix this, we first check if localStorage
+      // is available and then load the search plugin script. Consequently, the
+      // affected browsers don't see a search field, but the page still loads.
+      // See: https://github.com/Modernizr/Modernizr/issues/1825
+
+      function localStorageAvailable() {
+        // Source: https://stackoverflow.com/a/16427747
+        try {
+          localStorage.setItem('x', 'x');
+          localStorage.removeItem('x');
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+      if (localStorageAvailable() === true) {
+        // Source: https://www.html5rocks.com/en/tutorials/speed/script-loading/
+        var script = document.createElement('script');
+        script.src = 'https://cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js';
+        script.async = false;
+        document.head.appendChild(script);
+      }
+    </script>
   </head>
   <body>
     <div id="contents-page" class="tdb-d"></div>
@@ -61,7 +87,6 @@
     <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/js/docsify-themeable.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docsify-tabs@1"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/zoom-image.min.js"></script>
-    <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/@alertbox/docsify-footer/dist/docsify-footer.min.js"></script>
     <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
     <script src="https://unpkg.com/docsify-copy-code@2"></script>


### PR DESCRIPTION
Load the docsify search plugin only if localStorage is available.