### PR TITLE
docker: remove dev as a default tag

### DIFF
--- a/readme/terminusdb/install/install-as-docker-container.md
+++ b/readme/terminusdb/install/install-as-docker-container.md
@@ -62,10 +62,10 @@ Run the container using script `terminusdb-container`.
 
 #### Running for the first time
 
-Set the runtime environment to the development release `TERMINUSDB_TAG=dev` and run the container with parameter `run`. See [Environment configuration](install-as-docker-container.md#environment-configuration) for further configuration options.
+Run the container with the parameter `run`. See [Environment configuration](install-as-docker-container.md#environment-configuration) for further configuration options.
 
 ```bash
-TERMINUSDB_TAG=dev ./terminusdb-container run
+./terminusdb-container run
 ```
 
 This generates the message: `terminusdb-server container started https://127.0.0.1:6363/`. This is the TerminusDB Server and [Console](install-as-docker-container.md#use-the-console) URL.
@@ -81,7 +81,6 @@ This generates the message: `terminusdb-server container started https://127.0.0
 {% endhint %}
 
 ```bash
-TERMINUSDB_TAG=dev 
 ./terminusdb-container stop
 ./terminusdb-container rm
 ./terminusdb-container run


### PR DESCRIPTION
There is no reason why dev should be the default version for users