### PR TITLE
Remove package manager as dependency

### DIFF
--- a/readme/terminusdb/install/install-as-docker-container.md
+++ b/readme/terminusdb/install/install-as-docker-container.md
@@ -24,7 +24,6 @@ A list of prerequisite components depending on your operating system. Click on t
 | [Git Bash](https://git-scm.com/downloads)                            | `Latest` | Clone the TerminusDB bootstrap and run the container script. |       |       |    ✔    |
 | [Sudo](https://www.sudo.ws/download.html)                            | `Latest` | Access security.                                             |   ✔   |   ✔   |         |
 | [Docker](https://www.docker.com/products/docker-desktop)             | `Latest` | Use the TerminusDB docker container.                         |   ✔   |   ✔   |    ✔    |
-| [Package manager](https://www.docker.com/products/container-runtime) | `Latest` | Implement docker for Linux systems.                          |   ✔   |       |         |
 
 {% hint style="info" %}
 **Docker memory allocation on Windows**\


### PR DESCRIPTION
Every Linux distribution that we support has a package manager. There is no reason to specifically add it.