### PR TITLE
curl: remove instances of -k

### DIFF
--- a/readme/terminusx-db/reference-guides/curl.md
+++ b/readme/terminusx-db/reference-guides/curl.md
@@ -12,7 +12,7 @@ Use a hypothetical JSON file `/tmp/testschema.json` containing a schema.
 
 ```shell
 cat /tmp/testschema.json | \
-    curl -X POST -k 'http://localhost:6363/api/document/admin/foo?graph_type=schema&author=me&message=hallo&full_replace=true' \
+    curl -X POST 'http://localhost:6363/api/document/admin/foo?graph_type=schema&author=me&message=hallo&full_replace=true' \
         --data-binary @- -H 'Content-Type: application/json'
 ```
 
@@ -22,7 +22,7 @@ cat /tmp/testschema.json | \
 
 ```shell
 cat /tmp/testdata.json | \
-    curl -X POST -k 'http://localhost:6363/api/document/admin/foo?author=me&message=hallo' \
+    curl -X POST 'http://localhost:6363/api/document/admin/foo?author=me&message=hallo' \
         --data-binary @- -H 'Content-Type: application/json'
 ```
 
@@ -31,47 +31,46 @@ cat /tmp/testdata.json | \
 Note the `graph_type` is not specified in the first example. Explicitly requesting the `graph_type` instance, in the second example, provides the same result.  
 
 ```shell
-curl -k 'http://localhost:6363/api/document/admin/foo'
+curl 'http://localhost:6363/api/document/admin/foo'
 ```
 
 ```shell
-curl -k 'http://localhost:6363/api/document/admin/foo?graph_type=instance'
+curl 'http://localhost:6363/api/document/admin/foo?graph_type=instance'
 ```
 
 ### Get a list of instance documents of a particular type
 
 ```shell
-curl -k 'http://localhost:6363/api/document/admin/foo?type=Person'
+curl 'http://localhost:6363/api/document/admin/foo?type=Person'
 ```
 
 ### Get a particular instance document by id
 
 ```shell
-curl -k \
-    'http://localhost:6363/api/document/admin/foo?graph_type=instance?id=Person_Robin_1995-09-29'
+curl 'http://localhost:6363/api/document/admin/foo?graph_type=instance?id=Person_Robin_1995-09-29'
 ```
 
 ### Get a list of instance documents, skipping the first 3 and retrieving 5 more
 
 ```shell
-curl -k 'http://localhost:6363/api/document/admin/foo?skip=3&count=5'
+curl 'http://localhost:6363/api/document/admin/foo?skip=3&count=5'
 ```
 
 ### Get a list of instance documents, with each JSON object on its own line
 
 ```shell
-curl -k 'http://localhost:6363/api/document/admin/foo?minimized=true'
+curl 'http://localhost:6363/api/document/admin/foo?minimized=true'
 ```
 
 ### Get a list of instance documents, as a JSON list instead of a stream
 
 ```shell
-curl -k 'http://localhost:6363/api/document/admin/foo?as_list=true'
+curl 'http://localhost:6363/api/document/admin/foo?as_list=true'
 ```
 
 ### Delete a single object
 
 ```shell
-curl -X DELETE -k \
+curl -X DELETE \
     'http://localhost:6363/api/document/admin/foo?uthor=me&message=blah&id=Person_1adfe57f9a2285da051445a3cf6056ef06dc1b7a'
 ```


### PR DESCRIPTION
It is insecure and not needed since all the examples use localhost.