### PR TITLE
Fix outdated install-from-source instructions.

### DIFF
--- a/get-started/install/install-from-source-code.md
+++ b/get-started/install/install-from-source-code.md
@@ -26,7 +26,6 @@ A list of prerequisite components depending on your operating system. Click on t
 Install, build and run TerminusDB from source code with the following steps.
 
 * [Install SWI-Prolog](install-from-source-code.md#install-swi-prolog)
-* [Run SWI-Prolog](install-from-source-code.md#run-swi-prolog)
 * [Clone the TerminusDB repository](install-from-source-code.md#clone-the-terminusdb-repository)
 * [Make the TerminusDB Command Line Interface](install-from-source-code.md#make-the-terminusdb-command-line-interface)
 * [Run the TerminusDB system database](install-from-source-code.md#run-the-terminusdb-system-database)
@@ -92,15 +91,6 @@ brew install rust
 {% endtab %}
 {% endtabs %}
 
-### Run SWI-Prolog
-
-```
-swipl
-pack_install(terminus_store_prolog).
-pack_install(tus).
-halt.
-```
-
 ### Clone the TerminusDB repository
 
 Identical for all operating systems: Clone the `terminusdb` repository from GitHub.
@@ -117,14 +107,18 @@ git clone https://github.com/terminusdb/terminusdb
 {% tab title="Linux" %}
 ```bash
 cd terminusdb
+make install-tus
 make
+make install-dashboard
 ```
 {% endtab %}
 
 {% tab title="macOS" %}
 ```
 cd  terminusdb
+make install-tus
 make
+make install-dashboard
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The pack_install(terminus_store_prolog) step appears to be no longer necessary. (It also fails on nixos, and likely any other system that needs to pass env vars to cargo). 

The pack_install(tus) step can be replaced with the equivalent makefile target. Meaning there is no need to manually run swipl at all.

The instructions were also missing the target to install the dashboard, which I found to be a point of confusion.